### PR TITLE
Google+ shareボタン廃止

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -20,9 +20,6 @@
 
     <title>HeartRails - Software Design and Development Consultancy with Ruby on Rails / React / iOS & Android Apps</title>
     <script src="../javascripts/common.js"></script>
-    <script src="https://apis.google.com/js/platform.js" async defer>
-      {lang: 'en'}
-    </script>
   </head>
   <body>
     <div id="pagetop"></div>
@@ -316,9 +313,6 @@
             <ul>
               <li class="share-hatena">
                 <a href="http://b.hatena.ne.jp/entry/www.heartrails.com/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="en" title="Add this article to Hatena Bookmark"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="Add this article to Hatena Bookmark" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-              </li>
-              <li class="share-google">
-                <div class="g-plusone" data-size="medium" data-annotation="inline" data-width="120"></div>
               </li>
               <li class="share-twitter">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-lang="en">Tweet</a>

--- a/en/wanted/designer.html
+++ b/en/wanted/designer.html
@@ -22,9 +22,6 @@
 
     <title>Looking for fastidious designers who are and committed to top-quality UI/UX!</title>
     <script src="../../javascripts/common.js"></script>
-    <script src="https://apis.google.com/js/platform.js" async defer>
-      {lang: 'en'}
-    </script>
   </head>
   <body>
     <div id="pagetop"></div>
@@ -233,9 +230,6 @@
             <ul>
               <li class="share-hatena">
                 <a href="http://b.hatena.ne.jp/entry/www.heartrails.com/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="en" title="Add this article to Hatena Bookmark"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="Add this article to Hatena Bookmark" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-              </li>
-              <li class="share-google">
-                <div class="g-plusone" data-size="medium" data-annotation="inline" data-width="120"></div>
               </li>
               <li class="share-twitter">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-lang="en">Tweet</a>

--- a/en/wanted/engineer.html
+++ b/en/wanted/engineer.html
@@ -22,9 +22,6 @@
 
     <title>Recruiting for engineers who want to make development their calling! - HeartRails</title>
     <script src="/javascripts/common.js"></script>
-    <script src="https://apis.google.com/js/platform.js" async defer>
-      {lang: 'en'}
-    </script>
   </head>
   <body>
     <div id="pagetop"></div>
@@ -276,9 +273,6 @@
             <ul>
               <li class="share-hatena">
                 <a href="http://b.hatena.ne.jp/entry/www.heartrails.com/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="en" title="Add this article to Hatena Bookmark"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="Add this article to Hatena Bookmark" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-              </li>
-              <li class="share-google">
-                <div class="g-plusone" data-size="medium" data-annotation="inline" data-width="120"></div>
               </li>
               <li class="share-twitter">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-lang="en">Tweet</a>

--- a/index.html
+++ b/index.html
@@ -20,9 +20,6 @@
 
     <title>HeartRails - ハートレイルズ - Ruby on Rails や React、iOS／Android 開発に長けた、新規事業に特化した開発会社</title>
     <script src="javascripts/common.js"></script>
-    <script src="https://apis.google.com/js/platform.js" async defer>
-      {lang: 'ja'}
-    </script>
   </head>
   <body>
     <div id="pagetop"></div>
@@ -302,9 +299,6 @@
             <ul>
               <li class="share-hatena">
                 <a href="http://b.hatena.ne.jp/entry/www.heartrails.com/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-              </li>
-              <li class="share-google">
-                <div class="g-plusone" data-size="medium" data-annotation="inline" data-width="120"></div>
               </li>
               <li class="share-twitter">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-lang="ja">ツイート</a>

--- a/wanted/designer.html
+++ b/wanted/designer.html
@@ -22,9 +22,6 @@
 
     <title>UI／UX に妥協しない、こだわり抜くデザイナーを大募集！ - ハートレイルズ</title>
     <script src="/javascripts/common.js"></script>
-    <script src="https://apis.google.com/js/platform.js" async defer>
-      {lang: 'ja'}
-    </script>
   </head>
   <body>
     <div id="pagetop"></div>
@@ -233,9 +230,6 @@
             <ul>
               <li class="share-hatena">
                 <a href="http://b.hatena.ne.jp/entry/www.heartrails.com/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-              </li>
-              <li class="share-google">
-                <div class="g-plusone" data-size="medium" data-annotation="inline" data-width="120"></div>
               </li>
               <li class="share-twitter">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-lang="ja">ツイート</a>

--- a/wanted/engineer.html
+++ b/wanted/engineer.html
@@ -22,9 +22,6 @@
 
     <title>開発を一生の仕事にしたいエンジニアを大募集！ - ハートレイルズ</title>
     <script src="/javascripts/common.js"></script>
-    <script src="https://apis.google.com/js/platform.js" async defer>
-      {lang: 'ja'}
-    </script>
   </head>
   <body>
     <div id="pagetop"></div>
@@ -276,9 +273,6 @@
             <ul>
               <li class="share-hatena">
                 <a href="http://b.hatena.ne.jp/entry/www.heartrails.com/" class="hatena-bookmark-button" data-hatena-bookmark-layout="basic-label-counter" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
-              </li>
-              <li class="share-google">
-                <div class="g-plusone" data-size="medium" data-annotation="inline" data-width="120"></div>
               </li>
               <li class="share-twitter">
                 <a href="https://twitter.com/share" class="twitter-share-button" data-lang="ja">ツイート</a>


### PR DESCRIPTION
目的
====

2019年4月2日 をもって一般ユーザー向けの Google+ は利用できなくなる。
heartrails.github.io では share ボタンを利用しているので取り除く。

スクリーンショット
====

<img width="1410" alt="スクリーンショット 2019-03-23 21 31 11" src="https://user-images.githubusercontent.com/148184/54866073-1054fa00-4db3-11e9-81f6-25251ffeabfe.png">
